### PR TITLE
ACS 23 naming?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
     name: "compile"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
       - name: Build with Maven
         run: ./mvnw compile
 
@@ -27,11 +27,11 @@ jobs:
           - alfresco-version: 23.1.0
             experimental: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Run tests
         run: ./mvnw test -Pcommunity-${{ matrix.alfresco-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - alfresco-version: 6.1.2-ga
-            experimental: false
-          - alfresco-version: 6.2.0-ga
-            experimental: false
-          - alfresco-version: 7.1.0.1
-            experimental: false
-          - alfresco-version: 7.2.0
-            experimental: false
-          - alfresco-version: 7.3.0
+          - alfresco-version: 23.1.0
             experimental: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 17
       - name: Run tests
         run: ./mvnw test -Pcommunity-${{ matrix.alfresco-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,22 @@ jobs:
           java-version: 17
       - name: Run tests
         run: ./mvnw test -Pcommunity-${{ matrix.alfresco-version }}
+  publish:
+    name: "Publishing to Maven central"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 17
       - name: Build with Maven
         run: ./mvnw compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: build
 on:
   push:
   pull_request:
-
+    
 jobs:
   compile:
     name: "compile"
@@ -37,22 +37,3 @@ jobs:
           java-version: 17
       - name: Run tests
         run: ./mvnw test -Pcommunity-${{ matrix.alfresco-version }}
-  publish:
-    name: "Publishing to Maven central"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: Publish package
-        run: ./mvnw --batch-mode deploy -Dgpg.skip=true -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: mvn --batch-mode deploy -Dgpg.skip=true -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
+        run: ./mvnw --batch-mode deploy -Dgpg.skip=true -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: mvn --batch-mode deploy
+        run: mvn --batch-mode deploy -Dgpg.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish package
-        run: mvn --batch-mode deploy -Dgpg.skip=true
+        run: mvn --batch-mode deploy -Dgpg.skip=true -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: build
+on:
+  release:
+    types: [created]
+    
+jobs:
+  publish:
+    name: "Publishing to Maven central"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish package
+        run: ./mvnw --batch-mode deploy -Dgpg.skip=true -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: build
+name: publish
 on:
   release:
     types: [created]
@@ -18,8 +18,11 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish package
         run: ./mvnw --batch-mode deploy -Dgpg.skip=true -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish package
-        run: ./mvnw --batch-mode deploy -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
+        run: ./mvnw deploy -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2 -DskipTests=true
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish package
-        run: ./mvnw --batch-mode deploy -Dgpg.skip=true -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
+        run: ./mvnw --batch-mode deploy -DaltDeploymentRepository=ossrh::https://oss.sonatype.org/service/local/staging/deploy/maven2
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ local
 *.log.*
 
 private-key.gpg
+*.factorypath

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.3/apache-maven-3.9.3-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Profiles
 -
 We are using profiles to test against different Alfresco versions. If no configured Maven profiles are provided the default will be used and is specified by <activeByDefault>true</activeByDefault> in the pom.xml
 
-example: mvn package -Pcommunity-7.2.0
+example: mvn package -Pcommunity-23.1.0
 
 Testing
 -

--- a/alfresco-mvc-aop/pom.xml
+++ b/alfresco-mvc-aop/pom.xml
@@ -5,7 +5,7 @@
 
 	<parent>
 		<groupId>com.gradecak.alfresco-mvc</groupId>
-		<version>8.0.0</version>
+		<version>9.0.0</version>
 		<artifactId>alfresco-mvc-parent</artifactId>
 		<relativePath>../</relativePath>
 	</parent>

--- a/alfresco-mvc-aop/src/test/resources/test-aop-context.xml
+++ b/alfresco-mvc-aop/src/test/resources/test-aop-context.xml
@@ -12,7 +12,7 @@
   <context:property-placeholder location="values.properties" />
 
   <bean id="ServiceRegistry" class="org.mockito.Mockito" factory-method="mock">
-    <constructor-arg value="org.alfresco.service.ServiceRegistry" />
+    <constructor-arg value="org.alfresco.service.ServiceRegistry" type="java.lang.Class"/>
   </bean>
   
   <import resource="classpath:com/gradecak/alfresco-mvc/alfresco-mvc-aop.xml" />

--- a/alfresco-mvc-bom/pom.xml
+++ b/alfresco-mvc-bom/pom.xml
@@ -7,7 +7,7 @@
 	
 		<parent>
 		<groupId>com.gradecak.alfresco-mvc</groupId>
-		<version>8.0.0</version>
+		<version>9.0.0</version>
 		<artifactId>alfresco-mvc-parent</artifactId>
 		<relativePath>../</relativePath>
 	</parent>

--- a/alfresco-mvc-rest/pom.xml
+++ b/alfresco-mvc-rest/pom.xml
@@ -5,7 +5,7 @@
 
 	<parent>
 		<groupId>com.gradecak.alfresco-mvc</groupId>
-		<version>8.0.0</version>
+		<version>9.0.0</version>
 		<artifactId>alfresco-mvc-parent</artifactId>
 		<relativePath>../</relativePath>
 	</parent>

--- a/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/inheritservletconfig/WithSuffixControllerTest.java
+++ b/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/inheritservletconfig/WithSuffixControllerTest.java
@@ -80,17 +80,4 @@ public class WithSuffixControllerTest {
 		String contentAsString = res.getContentAsString();
 		Assertions.assertEquals("withsufix", contentAsString);
 	}
-//
-//	@Test
-//	public void when_alfrescoMvcDispatcherServletConfigOptionsWithoutSuffix_expect_ok() throws Exception {
-//		DispatcherServlet dispatcherServlet = dispatcherWebscript.getDispatcherServlet().getWebApplicationContext()
-//				.getBean(DispatcherServlet.class);
-//		Assertions.assertNotNull(dispatcherServlet);
-//
-//		MockHttpServletResponse res = mockWebscript.withControllerMapping("/test/withoutsufix").execute();
-//		Assertions.assertEquals(HttpStatus.OK.value(), res.getStatus());
-//
-//		String contentAsString = res.getContentAsString();
-//		Assertions.assertEquals("withoutsufix", contentAsString);
-//	}
 }

--- a/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/inheritservletconfig/WithoutSuffixControllerTest.java
+++ b/alfresco-mvc-rest/src/test/java/com/gradecak/alfresco/mvc/test/inheritservletconfig/WithoutSuffixControllerTest.java
@@ -59,28 +59,6 @@ public class WithoutSuffixControllerTest {
 		mockWebscript.newRequest();
 	}
 
-	/**
-	 * @deprecated as of Spring 5.2.4. See class-level note in
-	 *             {@link RequestMappingHandlerMapping} on the deprecation of path
-	 *             extension config options. As there is no replacement for this
-	 *             method, in Spring 5.2.x it is necessary to set it to
-	 *             {@code false}. In Spring 5.3 the default changes to {@code false}
-	 *             and use of this property becomes unnecessary.
-	 */
-//	@Deprecated
-//	@Test
-//	public void when_alfrescoMvcDispatcherServletConfigOptionsWithSuffix_expect_suffixHandledAndOk() throws Exception {
-//		DispatcherServlet dispatcherServlet = dispatcherWebscript.getDispatcherServlet().getWebApplicationContext()
-//				.getBean(DispatcherServlet.class);
-//		Assertions.assertNotNull(dispatcherServlet);
-//
-//		MockHttpServletResponse res = mockWebscript.withControllerMapping("/test/withsufix.test").execute();
-//		Assertions.assertEquals(HttpStatus.OK.value(), res.getStatus());
-//
-//		String contentAsString = res.getContentAsString();
-//		Assertions.assertEquals("withsufix", contentAsString);
-//	}
-
 	@Test
 	public void when_alfrescoMvcDispatcherServletConfigOptionsWithoutSuffix_expect_ok() throws Exception {
 		DispatcherServlet dispatcherServlet = dispatcherWebscript.getDispatcherServlet().getWebApplicationContext()

--- a/alfresco-mvc-rest/src/test/resources/mock-alfresco-context.xml
+++ b/alfresco-mvc-rest/src/test/resources/mock-alfresco-context.xml
@@ -13,16 +13,16 @@
   </bean>
   
   <bean id="ServiceRegistry" class="org.mockito.Mockito" factory-method="mock">
-    <constructor-arg value="org.alfresco.service.ServiceRegistry" />
+    <constructor-arg value="org.alfresco.service.ServiceRegistry" type="java.lang.Class"/>
   </bean>
   
   <bean id="NamespaceService" class="org.mockito.Mockito" factory-method="mock">
-    <constructor-arg value="org.alfresco.service.namespace.NamespaceService" />
+    <constructor-arg value="org.alfresco.service.namespace.NamespaceService" type="java.lang.Class"/>
   </bean>
   
   
   <bean id="webscriptHelper" class="org.mockito.Mockito" factory-method="mock">
-    <constructor-arg value="org.alfresco.rest.framework.webscripts.ResourceWebScriptHelper" />
+    <constructor-arg value="org.alfresco.rest.framework.webscripts.ResourceWebScriptHelper" type="java.lang.Class"/>
   </bean>  
 
   <!-- bean class="org.springframework.mock.web.MockServletContext" id="mockServletContext" />

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.gradecak.alfresco-mvc</groupId>
-	<version>8.0.0</version>
+	<version>9.0.0</version>
 	<artifactId>alfresco-mvc-parent</artifactId>
 	<packaging>pom</packaging>
 
@@ -40,9 +42,8 @@
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.build.sourceVersion>17</maven.build.sourceVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<dependency.jakarta.servlet-api.version>6.0.0</dependency.jakarta.servlet-api.version>
-		<dependency.mockito.version>4.8.1</dependency.mockito.version>
-		<dependency.junit-jupiter.version>5.9.1</dependency.junit-jupiter.version>
+		<dependency.mockito.version>5.7.0</dependency.mockito.version>
+		<dependency.junit-jupiter.version>5.10.1</dependency.junit-jupiter.version>
 	</properties>
 
 	<modules>
@@ -63,6 +64,15 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.alfresco</groupId>
+				<artifactId>alfresco-community-repo</artifactId>
+				<version>${dependency.alfresco-community-repo.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+				<optional>true</optional>
+			</dependency>
+
+			<dependency>
 				<groupId>com.gradecak.alfresco-mvc</groupId>
 				<artifactId>alfresco-mvc-rest</artifactId>
 				<version>${project.version}</version>
@@ -77,31 +87,12 @@
 			</dependency>
 
 			<dependency>
-				<groupId>jakarta.servlet</groupId>
-				<artifactId>jakarta.servlet-api</artifactId>
-				<version>${dependency.jakarta.servlet-api.version}</version>
-				<scope>provided</scope>
-			</dependency>
-
-			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>${dependency.mockito.version}</version>
 				<scope>provided</scope>
 			</dependency>
 
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-test</artifactId>
-				<version>${dependency.spring-test.version}</version>
-				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>junit</groupId>
-						<artifactId>junit</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-engine</artifactId>
@@ -118,7 +109,8 @@
 		</repository>
 		<repository>
 			<id>alfresco-public-snapshots</id>
-			<url>https://artifacts.alfresco.com/nexus/content/groups/public-snapshots</url>
+			<url>
+				https://artifacts.alfresco.com/nexus/content/groups/public-snapshots</url>
 			<snapshots>
 				<enabled>true</enabled>
 				<updatePolicy>daily</updatePolicy>
@@ -193,52 +185,13 @@
 
 	<profiles>
 		<profile>
-			<id>community-6.1.2-ga</id>
-			<properties>
-				<dependency.acs-community-packaging.version>6.1.2-ga</dependency.acs-community-packaging.version>
-				<dependency.spring-test.version>5.1.3.RELEASE</dependency.spring-test.version>
-			</properties>
-		</profile>
-	
-		<profile>
-			<id>community-6.2.0-ga</id>
-			<properties>
-				<dependency.acs-community-packaging.version>6.2.0-ga</dependency.acs-community-packaging.version>
-				<dependency.spring-test.version>5.1.8.RELEASE</dependency.spring-test.version>
-			</properties>
-		</profile>
-
-		<profile>
-			<id>community-7.1.0.1</id>
-			<properties>
-				<dependency.acs-community-packaging.version>7.1.0.1</dependency.acs-community-packaging.version>
-				<dependency.spring-test.version>5.3.9</dependency.spring-test.version>
-			</properties>
-		</profile>
-
-		<profile>
-			<id>community-7.2.0</id>
-			<properties>
-				<dependency.acs-community-packaging.version>7.2.0</dependency.acs-community-packaging.version>
-				<dependency.spring-test.version>5.3.15</dependency.spring-test.version>
-			</properties>
-		</profile>
-
-		<profile>
-			<id>community-7.3.0</id>
-			<properties>
-				<dependency.acs-community-packaging.version>7.3.0</dependency.acs-community-packaging.version>
-				<dependency.spring-test.version>5.3.23</dependency.spring-test.version>
-			</properties>
-		</profile>
-		<profile>
 			<id>community-23.1.0</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
 				<dependency.acs-community-packaging.version>23.1.0</dependency.acs-community-packaging.version>
-				<dependency.spring-test.version>6.1.0</dependency.spring-test.version>
+				<dependency.alfresco-community-repo.version>23.1.0.255</dependency.alfresco-community-repo.version>
 			</properties>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -123,12 +123,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.2.5</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -142,7 +142,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.7.0</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -155,7 +155,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.13.0</version>
 				<configuration>
 					<release>${maven.compiler.source}</release>
 				</configuration>
@@ -163,7 +163,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.4</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>


### PR DESCRIPTION
- upgrade of testing libraries
- removing jakarta servlet-api incompatible profiles
- version bump to 9.0.0? should we use 23.x to make it easier to follow alfresco versions?